### PR TITLE
fix: updating the http-cache-semantics version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
         "@semantic-release/changelog": "^6.0.2",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^8.0.7",
-        "http-cache-semantics": "^4.1.1"
+        "@semantic-release/github": "^8.0.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1480,11 +1479,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -7047,11 +7041,6 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
-    },
-    "http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-proxy-agent": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3164,7 +3164,7 @@
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true
@@ -3576,7 +3576,7 @@
       "dependencies": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
+        "http-cache-semantics": "^4.1.1",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
@@ -8220,7 +8220,7 @@
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "peer": true
         },
@@ -8516,7 +8516,7 @@
           "requires": {
             "agentkeepalive": "^4.2.1",
             "cacache": "^16.1.0",
-            "http-cache-semantics": "^4.1.0",
+            "http-cache-semantics": "^4.1.1",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "@semantic-release/changelog": "^6.0.2",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^8.0.7"
+        "@semantic-release/github": "^8.0.7",
+        "http-cache-semantics": "^4.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1479,6 +1480,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -7041,6 +7047,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-proxy-agent": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "@semantic-release/changelog": "^6.0.2",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^8.0.7"
+        "@semantic-release/github": "^8.0.7",
+        "http-cache-semantics": "^4.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1479,6 +1480,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -3164,7 +3170,7 @@
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.1",
+      "version": "4.1.0",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true
@@ -3576,7 +3582,7 @@
       "dependencies": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.1",
+        "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
@@ -7042,6 +7048,11 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+    },
     "http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -8220,7 +8231,7 @@
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.1",
+          "version": "4.1.0",
           "bundled": true,
           "peer": true
         },
@@ -8516,7 +8527,7 @@
           "requires": {
             "agentkeepalive": "^4.2.1",
             "cacache": "^16.1.0",
-            "http-cache-semantics": "^4.1.1",
+            "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^8.0.7",
-    "http-cache-semantics": "^4.1.1"
+    "@semantic-release/github": "^8.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^8.0.7"
+    "@semantic-release/github": "^8.0.7",
+    "http-cache-semantics": "^4.1.1"
   }
 }


### PR DESCRIPTION
dependency: none

## PR summary
Addressing the following vulnerability scan result:
http-cache-semantics vulnerable to Regular Expression Denial of Servic


**Fixes:** 
https://github.com/IBM/networking-python-sdk/security/dependabot/14

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe)

Updating one of the libraries. 

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->